### PR TITLE
update pom.xml to address cve CVE-2024-25710, CVE-2024-26308 and CVE-2023-5072

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tested under OPA version 0.26.0
 
 ## Warning
 - Very early stage project and almost sdk independent builtin functions not implemented(just place holder).
-- <del>If you are using an Apple Silicon Mac, see [FOR_APPLE_SILICON_USERS.md](./FOR_APPLE_SILICON_USERS.md) for first.,/del>
+- <del>If you are using an Apple Silicon Mac, see [FOR_APPLE_SILICON_USERS.md](./FOR_APPLE_SILICON_USERS.md) first./del>
 
 ## Usage
 
@@ -25,7 +25,7 @@ Tested under OPA version 0.26.0
     <dependency>
         <groupId>io.github.sangkeon</groupId>
         <artifactId>java-opa-wasm</artifactId>
-        <version>0.2.4</version>
+        <version>0.2.5</version>
     </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.sangkeon</groupId>
   <artifactId>java-opa-wasm</artifactId>
-  <version>0.2.4</version>
+  <version>0.2.5</version>
   <packaging>jar</packaging>
 
   <name>java-opa-wasm</name>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.23.0</version>
+      <version>1.26.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20230227</version>
+      <version>20231013</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
A few CVEs were found from the Trivy scan result and this PR intends to upgrade the library version for the following libraries

**org.apache.commons:commons-compress**
- Found CVEs
  - [CVE-2024-25710](https://avd.aquasec.com/nvd/cve-2024-25710)
  - [CVE-2024-26308](https://avd.aquasec.com/nvd/cve-2024-26308)
- Fixed version: `1.26.0`

**org.json:json**
- Found CVEs
 - [CVE-2023-5072](https://avd.aquasec.com/nvd/cve-2023-5072)
- Fixed version: `20231013`

